### PR TITLE
fix: increase size and spacing of slide indicators for tap-target sizing seo check

### DIFF
--- a/blocks/carousel/carousel.css
+++ b/blocks/carousel/carousel.css
@@ -63,16 +63,14 @@
 }
 
 .carousel .carousel-slide-indicators {
-  --carousel-indicator-size: 1.5rem;
-
   display: flex;
   justify-content: center;
-  gap: calc(var(--carousel-indicator-size) / 2);
+  gap: 1.5rem;
 }
 
 .carousel .carousel-slide-indicator button {
-  width: var(--carousel-indicator-size);
-  height: var(--carousel-indicator-size);
+  width: 1.25rem;
+  height: 1.25rem;
   padding: 0;
   border-radius: 50%;
   background-color: rgba(0 0 0 / 25%);

--- a/blocks/carousel/carousel.css
+++ b/blocks/carousel/carousel.css
@@ -63,16 +63,18 @@
 }
 
 .carousel .carousel-slide-indicators {
+  --carousel-indicator-size: 1.5rem;
+
   display: flex;
   justify-content: center;
-  gap: 0.5rem;
+  gap: calc(var(--carousel-indicator-size) / 2);
 }
 
 .carousel .carousel-slide-indicator button {
-  width: 1rem;
-  height: 1rem;
+  width: var(--carousel-indicator-size);
+  height: var(--carousel-indicator-size);
   padding: 0;
-  border-radius: 1rem;
+  border-radius: 50%;
   background-color: rgba(0 0 0 / 25%);
 }
 


### PR DESCRIPTION
Test URLs:
- Before: https://main--aem-block-collection--adobe.hlx.live/block-collection/carousel
- After: https://carousel-indicators-seo--aem-block-collection--adobe.hlx.live/block-collection/carousel
