### PR TITLE
feat: allow form block to submit to an arbitraty url

### DIFF
--- a/blocks/form/form.js
+++ b/blocks/form/form.js
@@ -7,7 +7,6 @@ async function createForm(formHref, submitHref) {
   const json = await resp.json();
 
   const form = document.createElement('form');
-  // eslint-disable-next-line prefer-destructuring
   form.dataset.action = submitHref;
 
   const fields = await Promise.all(json.data.map((fd) => createField(fd, form)));
@@ -105,6 +104,14 @@ export default async function decorate(block) {
         firstInvalidEl.focus();
         firstInvalidEl.scrollIntoView({ behavior: 'smooth' });
       }
+    }
+  });
+
+  window.addEventListener('pageshow', (event) => {
+    if (event.persisted) {
+      // re-enable form submission when back button is used
+      const submit = form.querySelector('button[type="submit"]');
+      if (submit) submit.disabled = false;
     }
   });
 }

--- a/blocks/form/form.js
+++ b/blocks/form/form.js
@@ -1,5 +1,4 @@
 import createField from './form-fields.js';
-import { sampleRUM } from '../../scripts/aem.js';
 
 async function createForm(formHref, submitHref) {
   const { pathname } = new URL(formHref);
@@ -44,13 +43,6 @@ function generatePayload(form) {
   return payload;
 }
 
-function handleSubmitError(form, error) {
-  // eslint-disable-next-line no-console
-  console.error(error);
-  form.querySelector('button[type="submit"]').disabled = false;
-  sampleRUM('form:error', { source: '.form', target: error.stack || error.message || 'unknown error' });
-}
-
 async function handleSubmit(form) {
   if (form.getAttribute('data-submitting') === 'true') return;
 
@@ -69,7 +61,6 @@ async function handleSubmit(form) {
       },
     });
     if (response.ok) {
-      sampleRUM('form:submit', { source: '.form', target: form.dataset.action });
       if (form.dataset.confirmation) {
         window.location.href = form.dataset.confirmation;
       }
@@ -78,9 +69,11 @@ async function handleSubmit(form) {
       throw new Error(error);
     }
   } catch (e) {
-    handleSubmitError(form, e);
+    // eslint-disable-next-line no-console
+    console.error(e);
   } finally {
     form.setAttribute('data-submitting', 'false');
+    submit.disabled = false;
   }
 }
 
@@ -104,14 +97,6 @@ export default async function decorate(block) {
         firstInvalidEl.focus();
         firstInvalidEl.scrollIntoView({ behavior: 'smooth' });
       }
-    }
-  });
-
-  window.addEventListener('pageshow', (event) => {
-    if (event.persisted) {
-      // re-enable form submission when back button is used
-      const submit = form.querySelector('button[type="submit"]');
-      if (submit) submit.disabled = false;
     }
   });
 }

--- a/blocks/form/form.js
+++ b/blocks/form/form.js
@@ -89,7 +89,7 @@ export default async function decorate(block) {
   const links = [...block.querySelectorAll('a')].map((a) => a.href);
   const formLink = links.find((link) => link.startsWith(window.location.origin) && link.endsWith('.json'));
   const submitLink = links.find((link) => link !== formLink);
-  if (!formLink) return;
+  if (!formLink || !submitLink) return;
 
   const form = await createForm(formLink, submitLink);
   block.replaceChildren(form);


### PR DESCRIPTION
Change form block to support an authored POST endpoint, since the form service is deprecated.

Test URLs:
- After: https://undeprecate-form--aem-block-collection--adobe.hlx.page/block-collection/form
