### PR TITLE
fix: add aria-label for links to achieve 100 a11y scores

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -65,6 +65,19 @@ function buildAutoBlocks(main) {
   }
 }
 
+function a11yLinks(main) {
+  const links = main.querySelectorAll('a');
+  links.forEach((link) => {
+    let label = link.textContent;
+    if (link.querySelector(':scope > span[class*="icon"]')) {
+      const icon = link.querySelector(':scope > span[class*="icon"]');
+      label = icon.classList[1].split('-')[1];
+      console.log(label);
+    }
+    link.setAttribute('aria-label', label);
+  });
+}
+
 /**
  * Decorates the main element.
  * @param {Element} main The main element
@@ -77,6 +90,8 @@ export function decorateMain(main) {
   buildAutoBlocks(main);
   decorateSections(main);
   decorateBlocks(main);
+  //add aria-label to links
+  a11yLinks(main);
 }
 
 /**


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #

Test URLs:
- Before: https://main--aem-block-collection--adobe.aem.live/block-collection/modal
- After: https://a11y-link-labels--aem-block-collection--adobe.aem.live/block-collection/modal
- Before: https://main--aem-block-collection--adobe.aem.live/block-collection/breadcrumbs
- After: https://a11y-link-labels--aem-block-collection--adobe.aem.live/block-collection/breadcrumbs