### PR TITLE
Support Cell alignment in Table Block

### DIFF
--- a/blocks/table/table.js
+++ b/blocks/table/table.js
@@ -25,6 +25,10 @@ export default async function decorate(block) {
     else tbody.append(row);
     [...child.children].forEach((col) => {
       const cell = buildCell(header ? i : i + 1);
+      const align = col.getAttribute('data-align');
+      const valign = col.getAttribute('data-valign');
+      if (align) cell.style.textAlign = align;
+      if (valign) cell.style.verticalAlign = valign;
       cell.innerHTML = col.innerHTML;
       row.append(cell);
     });


### PR DESCRIPTION
The Table block does not take into account any cell alignment values (align top, middle, bottom, left, right, center), and while this data is passed from the document to EDS via the `data-align` and `data-valign` attributes, these attributes are lost when the `<td>` cells are created. In this PR, I have added support for these properties by adding cell styles based on the data properties found in the `<div>`.

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--aem-block-collection--adobe.hlx.page/block-collection/table
- After: https://main--aem-block-collection--yumeniiru.aem.page/