### PR TITLE
chore: reset modal back to default position (fixed)

### DIFF
--- a/blocks/modal/modal.css
+++ b/blocks/modal/modal.css
@@ -9,7 +9,6 @@ body.modal-open {
 .modal dialog {
   overscroll-behavior: none;
   overflow-y: hidden;
-  position: relative;
   width: calc(100vw - 48px);
   max-width: 900px;
   max-height: calc(100dvh - (2 * var(--header-height)));


### PR DESCRIPTION
reseting `position` from `relative` to default (fixed) which seems to be the intuitive choice for a modal?

- Before: https://main--aem-block-collection--adobe.aem.live/block-collection/modal
- After: https://modal-fixed--aem-block-collection--adobe.aem.live/block-collection/modal