### PR TITLE
fix: prevent protocol-relative URLs in fragment loader (#132)

### DIFF
--- a/blocks/fragment/fragment.js
+++ b/blocks/fragment/fragment.js
@@ -18,7 +18,7 @@ import {
  * @returns {Promise<HTMLElement>} The root element of the fragment
  */
 export async function loadFragment(path) {
-  if (path && path.startsWith('/')) {
+  if (path && path.startsWith('/') && !path.startsWith('//')) {
     const resp = await fetch(`${path}.plain.html`);
     if (resp.ok) {
       const main = document.createElement('main');


### PR DESCRIPTION
Now requires paths to start with '/' but not '//' to ensure only same-origin relative URLs are accepted.

Fix #132

Test URLs:
- https://main--aem-block-collection--adobe.aem.live/