### PR TITLE
fix(regression): revert aem.js update to v3.1.0

### DIFF
--- a/scripts/aem.js
+++ b/scripts/aem.js
@@ -471,6 +471,24 @@ function decorateSections(main) {
     section.classList.add('section');
     section.dataset.sectionStatus = 'initialized';
     section.style.display = 'none';
+
+    // Process section metadata
+    const sectionMeta = section.querySelector('div.section-metadata');
+    if (sectionMeta) {
+      const meta = readBlockConfig(sectionMeta);
+      Object.keys(meta).forEach((key) => {
+        if (key === 'style') {
+          const styles = meta.style
+            .split(',')
+            .filter((style) => style)
+            .map((style) => toClassName(style.trim()));
+          styles.forEach((style) => section.classList.add(style));
+        } else {
+          section.dataset[toCamelCase(key)] = meta[key];
+        }
+      });
+      sectionMeta.parentNode.remove();
+    }
   });
 }
 


### PR DESCRIPTION
Restores section metadata processing in `decorateSections()` that was accidentally removed by the aem.js@3.1.0 update (#133). The missing code read `div.section-metadata` blocks, applied `style` values as CSS classes on the section, set other keys as `data-*` attributes, and removed the metadata element from the DOM.

**Preview:** https://fix-section-metadata-regression--aem-block-collection--adobe.aem.page/block-collection/section-metadata

🤖 Generated with Claude Code