### PR TITLE
feat(lib): update scripts/aem.js to aem.js@3.1.2

### DIFF
--- a/scripts/aem.js
+++ b/scripts/aem.js
@@ -93,14 +93,18 @@ function sampleRUM(checkpoint, data) {
         sampleRUM.baseURL = sampleRUM.baseURL || new URL(window.RUM_BASE || '/', new URL('https://ot.aem.live'));
         sampleRUM.collectBaseURL = sampleRUM.collectBaseURL || sampleRUM.baseURL;
         sampleRUM.sendPing = (ck, time, pingData = {}) => {
+          const uaExtra = navigator.webdriver && !navigator.userAgent.includes('+http')
+            ? { ua: `${navigator.userAgent} +http://navigator.webdriver` }
+            : {};
           // eslint-disable-next-line max-len, object-curly-newline
           const rumData = JSON.stringify({
             weight,
             id,
-            referer: window.location.href,
+            referer: window.location.origin + window.location.pathname,
             checkpoint: ck,
             t: time,
             ...pingData,
+            ...uaExtra,
           });
           const urlParams = window.RUM_PARAMS
             ? new URLSearchParams(window.RUM_PARAMS).toString() || ''
@@ -471,24 +475,6 @@ function decorateSections(main) {
     section.classList.add('section');
     section.dataset.sectionStatus = 'initialized';
     section.style.display = 'none';
-
-    // Process section metadata
-    const sectionMeta = section.querySelector('div.section-metadata');
-    if (sectionMeta) {
-      const meta = readBlockConfig(sectionMeta);
-      Object.keys(meta).forEach((key) => {
-        if (key === 'style') {
-          const styles = meta.style
-            .split(',')
-            .filter((style) => style)
-            .map((style) => toClassName(style.trim()));
-          styles.forEach((style) => section.classList.add(style));
-        } else {
-          section.dataset[toCamelCase(key)] = meta[key];
-        }
-      });
-      sectionMeta.parentNode.remove();
-    }
   });
 }
 


### PR DESCRIPTION
feat(lib): update scripts/aem.js to aem.js@3.1.2

Matches [adobe/aem-boilerplate@main/scripts/aem.js](https://github.com/adobe/aem-boilerplate/blob/main/scripts/aem.js) exactly.

Notable RUM changes from v3.1.2 ([aem-lib v3.0.2...v3.1.2](https://github.com/adobe/aem-lib/compare/v3.0.2...v3.1.2)):
- `sampleRUM.sendPing` now flags webdriver UAs by appending `+http://navigator.webdriver` to the user agent
- RUM `referer` field now uses `origin + pathname` instead of full `href` (strips query/hash)
- `@adobe/helix-rum-js` bumped to v2.15.0

The local section-metadata patch inside `decorateSections` (added by #136) is dropped to keep the file byte-identical to the boilerplate.

**Preview:** https://issue-aem-js-3-1-2--aem-block-collection--adobe.aem.page/

🤖 Generated with Claude Code